### PR TITLE
Initial implementation of SDK cache

### DIFF
--- a/graffitabsdk/build.gradle
+++ b/graffitabsdk/build.gradle
@@ -41,7 +41,7 @@ def persistentCookieJarVersion = "v1.0.0"
 def daggerVersion = "2.7"
 def jUnitVersion = "4.12"
 def jsr250Version = "1.0"
-
+def commonsCodecVersion = "1.10"
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile "junit:junit:$jUnitVersion"
@@ -51,6 +51,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-gson:$converterGsonVersion"
     compile "com.squareup.okhttp3:logging-interceptor:$okHttpLoggingInterceptorVersion"
     compile "org.projectlombok:lombok:$lombokVersion"
+    compile "commons-codec:commons-codec:$commonsCodecVersion"
     testCompile "org.projectlombok:lombok:$lombokVersion"
     testCompile "org.mockito:mockito-all:$mockitoVersion"
     provided "org.glassfish:javax.annotation:$javaxAnnotationVersion"
@@ -59,4 +60,5 @@ dependencies {
     compile "com.google.dagger:dagger:$daggerVersion"
     provided "javax.annotation:jsr250-api:$jsr250Version"
     apt "org.projectlombok:lombok:$lombokVersion"
+
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/MainTesting.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/MainTesting.java
@@ -84,8 +84,85 @@ public class MainTesting {
         GTSDK.getUserManager().login("david", "password1", responseHandler);
     }
 
+
+    private void performCachedCalls() {
+        GTResponseHandler<GTUser> responseHandler = new GTResponseHandler<GTUser>() {
+
+            @Override
+            public void onSuccess(GTResponse<GTUser> gtResponse) {
+                System.out.println("Logged in");
+                final long startTime = System.currentTimeMillis();
+                GTSDK.getUserManager().getMe(new GTResponseHandler<GTUser>() {
+
+                    @Override
+                    public void onSuccess(GTResponse<GTUser> gtResponse) {
+                        System.out.println("Get me (1)");
+                        final long interm = (System.currentTimeMillis() - startTime);
+                        final long start2 = System.currentTimeMillis();
+                        System.out.println("Took: " + interm);
+
+                        GTSDK.getUserManager().getMe(new GTResponseHandler<GTUser>() {
+
+                            @Override
+                            public void onSuccess(GTResponse<GTUser> gtResponse) {
+                                System.out.println("Get me (2)");
+                                GTUser user = gtResponse.getObject();
+                                System.out.println("Invoked endpoint: " + gtResponse.getApiEndpointUrl());
+                                System.out.println("- firstname:     " + user.firstName);
+                                System.out.println("- lastname:      " + user.lastName);
+                                System.out.println("Logged in user: " + GTSDK.getAccountManager().getLoggedInUser());
+                                final long interm = (System.currentTimeMillis() - start2);
+                                System.out.println("Took: " + interm);
+                            }
+
+                            @Override
+                            public void onFailure(GTResponse<GTUser> gtResponse) {
+                                System.out.println("Failure detected");
+                                System.out.println("Invoked endpoint: " + gtResponse.getApiEndpointUrl());
+                                System.out.println("Error: " + gtResponse.getResultCode() +
+                                        " - " + gtResponse.getResultDetail());
+                            }
+
+                            @Override
+                            public void onCache(GTResponse<GTUser> gtResponse) {
+                                System.out.println("Got cached response");
+                                GTUser user = gtResponse.getObject();
+                                System.out.println("Invoked endpoint: " + gtResponse.getApiEndpointUrl());
+                                System.out.println("- firstname:     " + user.firstName);
+                                System.out.println("- lastname:      " + user.lastName);
+                                System.out.println("Logged in user: " + GTSDK.getAccountManager().getLoggedInUser());
+                                final long interm = (System.currentTimeMillis() - start2);
+                                System.out.println("Took: " + interm);
+                            }
+
+                        });
+                    }
+
+                    @Override
+                    public void onFailure(GTResponse<GTUser> gtResponse) {
+                        System.out.println("Failure detected");
+                        System.out.println("Invoked endpoint: " + gtResponse.getApiEndpointUrl());
+                        System.out.println("Error: " + gtResponse.getResultCode() +
+                                " - " + gtResponse.getResultDetail());
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(GTResponse<GTUser> gtResponse) {
+                System.out.println("Failure detected");
+                System.out.println("Invoked endpoint: " + gtResponse.getApiEndpointUrl());
+                System.out.println("Error: " + gtResponse.getResultCode() +
+                        " - " + gtResponse.getResultDetail());
+            }
+        };
+        GTSDK.getUserManager().login("david", "password1", responseHandler);
+    }
+
+
     public static void main(String[] args) throws Exception {
         MainTesting mainTesting = new MainTesting();
-        mainTesting.performCall();
+        //mainTesting.performCall();
+        mainTesting.performCachedCalls();
     }
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/config/GTSDK.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/config/GTSDK.java
@@ -35,6 +35,10 @@ public class GTSDK {
         return get().userComponent.getAccountManager();
     }
 
+    public static void invalidateCache() {
+        get().userComponent.getCacheService().invalidateCache();
+    }
+
     public void inject(Activity activity) {
         get().userComponent.inject(activity);
     }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/components/UserComponent.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/components/UserComponent.java
@@ -9,6 +9,7 @@ import com.graffitabsdk.config.GTConfig;
 import com.graffitabsdk.config.dagger.modules.AppModule;
 import com.graffitabsdk.config.dagger.modules.NetworkModule;
 import com.graffitabsdk.config.dagger.modules.UserModule;
+import com.graffitabsdk.tasks.cache.GTCacheService;
 import dagger.Component;
 
 import javax.inject.Singleton;
@@ -24,6 +25,7 @@ public interface UserComponent {
     void inject(Activity activity);
     GTUserManager getUserManager();
     GTAccountManager getAccountManager();
+    GTCacheService getCacheService();
 
     static final class Initializer {
         private Initializer() {}

--- a/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/modules/AppModule.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/modules/AppModule.java
@@ -1,11 +1,11 @@
 package com.graffitabsdk.config.dagger.modules;
 
-import javax.inject.Singleton;
-
 import android.app.Application;
 import android.support.annotation.Nullable;
 import dagger.Module;
 import dagger.Provides;
+
+import javax.inject.Singleton;
 
 /**
  * Created by david on 03/12/2016.

--- a/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/modules/NetworkModule.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/config/dagger/modules/NetworkModule.java
@@ -11,6 +11,8 @@ import com.graffitabsdk.config.okhttp.LanguageHeaderInterceptor;
 import com.graffitabsdk.constants.GTApiConstants;
 import com.graffitabsdk.log.GTLog;
 import com.graffitabsdk.network.common.GTSharedPrefsCookiePersistor;
+import com.graffitabsdk.tasks.cache.GTCache;
+import com.graffitabsdk.tasks.cache.GTSharedPrefsCache;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.Cookie;
@@ -23,7 +25,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 import javax.inject.Singleton;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by david on 03/12/2016.
@@ -102,5 +106,38 @@ public class NetworkModule {
                 .addInterceptor(new LanguageHeaderInterceptor())
                 .addInterceptor(httpLoggingInterceptor)
                 .build();
+    }
+
+    @Provides
+    @Singleton
+    GTCache provideCache(@Nullable  Application application, Gson gson) {
+        if (application == null) {
+            //TODO: change when having tests
+            return new GTCache() {
+                private Map<String, Object> cache = new HashMap<>();
+                @Override
+                public <T> T readFromCache(String key) {
+                    Object value = cache.get(key);
+
+                    if (value == null) {
+                        return null;
+                    } else {
+                        return (T) value;
+                    }
+                }
+
+                @Override
+                public void invalidateCache() {
+                    cache.clear();
+                }
+
+                @Override
+                public <T> void writeValueToCache(String key, T value) {
+                    cache.put(key, value);
+                }
+            };
+        } else {
+            return new GTSharedPrefsCache(application, gson);
+        }
     }
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/network/common/GTResponse.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/network/common/GTResponse.java
@@ -14,11 +14,13 @@ public class GTResponse<T> {
     private Integer statusCode;
     private T object;
     private String apiEndpointUrl;
+    private Boolean isSuccessful;
 
     public GTResponse(T object) {
         this.object = object;
         this.resultCode = ResultCode.OK;
         this.statusCode = 200;
+        this.isSuccessful = true;
     }
 
     public GTResponse(T object, ResultCode resultCode) {
@@ -36,6 +38,7 @@ public class GTResponse<T> {
         response.setStatusCode(resultCode.getStatusCode());
         response.setApiEndpointUrl(apiEndpointUrl);
         response.setResultDetail(errorMessage);
+        response.setIsSuccessful(false);
         return response;
     }
 
@@ -46,6 +49,7 @@ public class GTResponse<T> {
         response.setStatusCode(statusCode);
         response.setApiEndpointUrl(apiEndpointUrl);
         response.setResultDetail(errorMessage);
+        response.setIsSuccessful(false);
         return response;
     }
 

--- a/graffitabsdk/src/main/java/com/graffitabsdk/network/common/GTResponseHandler.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/network/common/GTResponseHandler.java
@@ -3,9 +3,12 @@ package com.graffitabsdk.network.common;
 /**
  * Created by david on 10/11/2016.
  */
-
-// Abstract class in preparation for cache
 public abstract class GTResponseHandler<T> {
     public abstract void onSuccess(GTResponse<T> gtResponse);
-    public abstract void onFailure(GTResponse<T> responseObject);
+    public abstract void onFailure(GTResponse<T> gtResponse);
+
+    public void onCache(GTResponse<T> gtResponse) {
+        // Defaults to empty implementation so that the clients of the SDK do not need to forcibly implement
+        // a cache behaviour
+    }
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTCache.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTCache.java
@@ -1,0 +1,11 @@
+package com.graffitabsdk.tasks.cache;
+
+/**
+ * Created by david on 16/12/2016.
+ */
+
+public interface GTCache {
+    <T> T readFromCache(String key);
+    void invalidateCache();
+    <T> void writeValueToCache(String key, T value);
+}

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTCacheService.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTCacheService.java
@@ -1,0 +1,47 @@
+package com.graffitabsdk.tasks.cache;
+
+import com.graffitabsdk.network.common.GTResponse;
+import com.graffitabsdk.network.common.ResultCode;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import javax.inject.Inject;
+
+/**
+ * Created by david on 27/12/2016.
+ */
+
+public class GTCacheService {
+
+    private GTCache gtCache;
+
+    @Inject
+    public GTCacheService(GTCache gtCache) {
+        this.gtCache = gtCache;
+    }
+
+    public <T> GTResponse<T> resolveRequestFromCache(String apiEndpointUrl) {
+        GTResponse<T> gtResponse = new GTResponse<>();
+        gtResponse.setApiEndpointUrl(apiEndpointUrl);
+        String cacheKey = hashApiEndpoint(apiEndpointUrl);
+        T decodedResponse = gtCache.readFromCache(cacheKey);
+        gtResponse.setObject(decodedResponse);
+        gtResponse.setResultCode(ResultCode.OK);
+        gtResponse.setIsSuccessful(true);
+        return gtResponse;
+    }
+
+    public <T> void saveResponseToCache(GTResponse<T> gtResponse) {
+        String cacheKey = hashApiEndpoint(gtResponse.getApiEndpointUrl());
+        gtCache.writeValueToCache(cacheKey, gtResponse.getObject());
+    }
+
+    public void invalidateCache() {
+        gtCache.invalidateCache();
+    }
+
+    private String hashApiEndpoint(String apiEndpointUrl) {
+        // In older versions of Android there were some problems with this, replace with
+        // 'return new String(Hex.encodeHex(DigestUtils.md5(apiEndpointUrl)))' if this way does not work
+        return DigestUtils.md5Hex(apiEndpointUrl);
+    }
+}

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTSharedPrefsCache.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/cache/GTSharedPrefsCache.java
@@ -1,0 +1,57 @@
+package com.graffitabsdk.tasks.cache;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.SharedPreferences;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import javax.inject.Inject;
+import java.lang.reflect.Type;
+
+/**
+ * Created by david on 16/12/2016.
+ */
+
+public class GTSharedPrefsCache implements GTCache {
+
+    private static final String API_CACHE_KEY = "API_CACHE_KEY";
+    private Application application;
+    private Gson gson;
+
+    @Inject
+    public GTSharedPrefsCache(Application application, Gson gson) {
+        this.application = application;
+        this.gson = gson;
+    }
+
+    @Override
+    public <T> T readFromCache(String key) {
+        String json = getSharedPreferences(application).getString(key, null);
+        if (json != null) {
+            Type typeOfT = new TypeToken<T>() {}.getType();
+            return gson.fromJson(json, typeOfT);
+        }
+        return null;
+    }
+
+    @Override
+    public void invalidateCache() {
+        SharedPreferences.Editor editor = getSharedPreferences(application).edit();
+        editor.clear();
+        editor.apply();
+    }
+
+    @Override
+    public <T> void writeValueToCache(String key, T value) {
+        String json = gson.toJson(value);
+        SharedPreferences.Editor editor = getSharedPreferences(application).edit();
+        editor.putString(key, json);
+        editor.apply();
+    }
+
+    private SharedPreferences getSharedPreferences(Application application) {
+        return application.getApplicationContext()
+                .getSharedPreferences(API_CACHE_KEY, Context.MODE_PRIVATE);
+    }
+}

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/common/GTCall.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/common/GTCall.java
@@ -36,6 +36,7 @@ public abstract class GTCall<T> {
         GTResponse<T> gtResponse = new GTResponse<T>();
         T decodedResponse = decodeResponse();
         gtResponse.setObject(decodedResponse);
+        gtResponse.setIsSuccessful(true);
 
         gtResponse.setResultCode(ResultCode.OK);
         gtResponse.setApiEndpointUrl(apiEndpointUrl);

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/common/GTNetworkTask.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/common/GTNetworkTask.java
@@ -3,6 +3,7 @@ package com.graffitabsdk.tasks.common;
 import com.graffitabsdk.network.common.GTResponse;
 import com.graffitabsdk.network.common.GTResponseHandler;
 import com.graffitabsdk.network.common.RequestPerformed;
+import com.graffitabsdk.tasks.cache.GTCacheService;
 import retrofit2.Call;
 
 import java.util.Map;
@@ -11,27 +12,43 @@ import java.util.Map;
 /**
  * Created by david on 09/11/2016.
  */
-public abstract class GTNetworkTask<T>  {
+public abstract class GTNetworkTask<T> {
+
+    protected GTCacheService cacheService;
 
     protected RequestPerformed<T> performJsonRequest(Call<Map<String,T>> request, String propertyNameToExtract,
-                                                     GTResponseHandler<T> responseHandler) {
-        GTCall<T> call = GTCall.jsonCall(request, propertyNameToExtract, getAfterCompletionOperations());
+                                                     GTResponseHandler<T> responseHandler, boolean shouldUseCache) {
+        boolean isGetRequest = request.request().method().equalsIgnoreCase("GET");
+        AfterCompletionOperation<T> afterCompletionOperation = getAfterCompletionOperations(shouldUseCache, isGetRequest);
+        GTCall<T> call = GTCall.jsonCall(request, propertyNameToExtract, afterCompletionOperation);
         RequestPerformed<T> requestPerformed = new RequestPerformed<>(call);
+
+        // Try to resolve from cache
+        resolveCallFromCacheIfPossible(call.getApiEndpointUrl(), responseHandler, shouldUseCache, isGetRequest);
+
+        // The network call is executed anyway
         call.execute(responseHandler);
         return requestPerformed;
     }
 
+    /**
+     * Requests that do not get root JSON object as a response. These responses are never cached
+     * @param request
+     * @param responseHandler
+     * @return
+     */
     protected RequestPerformed<T> performRawRequest(Call<T> request, GTResponseHandler<T> responseHandler) {
-        GTCall<T> call = GTCall.rawCall(request, getAfterCompletionOperations());
+        GTCall<T> call = GTCall.rawCall(request, getAfterCompletionOperations(false, false));
         RequestPerformed<T> requestPerformed = new RequestPerformed<>(call);
         call.execute(responseHandler);
         return requestPerformed;
     }
 
-    private AfterCompletionOperation<T> getAfterCompletionOperations() {
+    private AfterCompletionOperation<T> getAfterCompletionOperations(final boolean shouldUseCache, final boolean isGetRequest) {
         return new AfterCompletionOperation<T>() {
             @Override
             public void executeOnSuccess(GTResponse<T> gtResponse) {
+                saveResponseToCacheIfPossible(gtResponse, shouldUseCache, isGetRequest);
                 performExtraOperationOnSuccess(gtResponse);
             }
 
@@ -50,5 +67,31 @@ public abstract class GTNetworkTask<T>  {
     protected void performExtraOperationOnFailure(GTResponse<T> gtResponse) {
         // Subclasses can provide custom code to execute by the SDK (like save an user, clear cache etc)
         // when the call failed
+    }
+
+    private void resolveCallFromCacheIfPossible(String apiEndpointUrl, GTResponseHandler<T> responseHandler,
+                                            boolean requestShouldUseCache, boolean isGetRequest) {
+        if (requestShouldUseCache && isGetRequest) {
+
+            if (cacheService == null) {
+                throw new IllegalStateException("Request requiring cache provides a null cacheService");
+            }
+
+            GTResponse<T> gtResponse = cacheService.resolveRequestFromCache(apiEndpointUrl);
+            if (gtResponse.getObject() != null) {
+                // Cache hit, execute cache handler on the app side -- only execute the handler in case of a cache hit
+                responseHandler.onCache(gtResponse);
+            }
+            // if there is a cache miss, go ahead like there were no cache
+        }
+    }
+
+    private void saveResponseToCacheIfPossible(GTResponse<T> gtResponse, boolean shouldUseCache, boolean isGetRequest) {
+        if (shouldUseCache && isGetRequest) {
+            if (cacheService == null) {
+                throw new IllegalStateException("Request requiring cache provides a null cacheService");
+            }
+            cacheService.saveResponseToCache(gtResponse);
+        }
     }
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/GTUserTasks.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/GTUserTasks.java
@@ -4,6 +4,7 @@ import com.graffitabsdk.model.GTUser;
 import com.graffitabsdk.network.common.GTResponseHandler;
 import com.graffitabsdk.network.common.RequestPerformed;
 import com.graffitabsdk.network.service.user.UserService;
+import com.graffitabsdk.tasks.cache.GTCacheService;
 import com.graffitabsdk.tasks.common.GTNetworkTask;
 
 import javax.inject.Inject;
@@ -17,11 +18,12 @@ public class GTUserTasks extends GTNetworkTask<GTUser> {
     private UserService userService;
 
     @Inject
-    public GTUserTasks(UserService userService) {
+    public GTUserTasks(UserService userService, GTCacheService gtCacheService) {
+        super.cacheService = gtCacheService;
         this.userService = userService;
     }
 
     public RequestPerformed<GTUser> getMe(GTResponseHandler<GTUser> responseHandler) {
-        return performJsonRequest(userService.getMe(), "user", responseHandler);
+        return performJsonRequest(userService.getMe(), "user", responseHandler, true);
     }
 }

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/login/GTLoginTasks.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/login/GTLoginTasks.java
@@ -28,7 +28,7 @@ public class GTLoginTasks extends GTNetworkTask<GTUser> {
     public RequestPerformed<GTUser> login(String username, String password,
                                           GTResponseHandler<GTUser> responseHandler) {
         LoginData loginData = new LoginData(username, password);
-        return performJsonRequest(userService.login(loginData), "user", responseHandler);
+        return performJsonRequest(userService.login(loginData), "user", responseHandler, false);
     }
 
     public RequestPerformed<GTUser> loginWithExternalProvider() {

--- a/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/login/GTLogoutTask.java
+++ b/graffitabsdk/src/main/java/com/graffitabsdk/tasks/user/login/GTLogoutTask.java
@@ -4,6 +4,7 @@ import com.graffitabsdk.network.common.GTResponse;
 import com.graffitabsdk.network.common.GTResponseHandler;
 import com.graffitabsdk.network.common.RequestPerformed;
 import com.graffitabsdk.network.service.user.UserService;
+import com.graffitabsdk.tasks.cache.GTCacheService;
 import com.graffitabsdk.tasks.common.GTNetworkTask;
 
 import javax.inject.Inject;
@@ -16,10 +17,12 @@ public class GTLogoutTask extends GTNetworkTask<Void> {
 
     private UserService userService;
     private LoggedInUserPersistor loggedInUserPersistor;
+    private GTCacheService cacheService;
 
     @Inject
-    public GTLogoutTask(UserService userService, LoggedInUserPersistor loggedInUserPersistor) {
+    public GTLogoutTask(UserService userService, LoggedInUserPersistor loggedInUserPersistor, GTCacheService cacheService) {
         this.userService = userService;
+        this.cacheService = cacheService;
         this.loggedInUserPersistor = loggedInUserPersistor;
     }
 
@@ -30,5 +33,6 @@ public class GTLogoutTask extends GTNetworkTask<Void> {
     @Override
     protected void performExtraOperationOnSuccess(GTResponse<Void> gtResponse) {
         loggedInUserPersistor.clearLoggedInUser();
+        cacheService.invalidateCache();
     }
 }


### PR DESCRIPTION
- Initial version, might not comply with all requirements from the app side
- Very lightly tested with main method just checking a cached version is returned instead of waiting for the network call to resolve.
- Assumes the app handles the case where there is a cache hit but also a network failure (should render the cached response, ignore the failure?)
- The flag 'shouldUseCache' might not be necessary (use cache in all GETs if a `cacheService` is provided)
- We may need to expose somewhere (GTSDK?) the `invalidateCache` operation
- The response from rawCalls (non JSON responses) is never cached
- The `cacheService` must be provided by subclasses of `GTNetworkTask` when required by a specific endpoint (task). This is needed due to the limitation of DI which cannot inject the service into an abstract class.
